### PR TITLE
ダイアログで表示される画像が異なる問題対応 #5

### DIFF
--- a/app/src/main/java/com/eure/traveling/ShotsListAdapter.java
+++ b/app/src/main/java/com/eure/traveling/ShotsListAdapter.java
@@ -30,7 +30,7 @@ public class ShotsListAdapter extends BaseAdapter{
     }
 
     @Override
-    public Object getItem(int position) {
+    public Shots getItem(int position) {
         return shotsList.get(position);
     }
 

--- a/app/src/main/java/com/eure/traveling/ShotsListFragment.java
+++ b/app/src/main/java/com/eure/traveling/ShotsListFragment.java
@@ -89,7 +89,7 @@ public class ShotsListFragment extends ListFragment implements AbsListView.OnScr
         Log.i(TAG, "position = " + position);
         Log.i(TAG, "id = " + id);
         super.onListItemClick(l, v, position, id);
-        DetailDialogFragment detailDialogFragment = DetailDialogFragment.newInstance(mList.get(position).imageUrl);
+        DetailDialogFragment detailDialogFragment = DetailDialogFragment.newInstance(mAdapter.getItem(position).getImageUrl());
         detailDialogFragment.show(getFragmentManager(), TAG);
     }
 


### PR DESCRIPTION
## Issue
https://github.com/eure/traveling/issues/5

## 修正概要
・ShotsListAdapterのgetItemの型をObject→Shotsに変更
・DetailDialogFragmentの初期化で使うImageUrlをAdapterから取得するように変更
→DetailDialogFragment拡張してタイトル出したい時とかも容易なはず。
