### PR TITLE
Fix #7 Add Access Token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ _sandbox
 # Crashlytics files
 crashlytics-build.properties
 com_crashlytics_export_strings.xml
+
+# Secrets keys
+secrets.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion 14
         versionCode 1
         versionName "1.0"
+        buildConfigField("String", "DRIBBBLE_ACCESS_TOKEN", "\""+getDribbbleAccessToken()+"\"")
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/eure/traveling/MyRequest.java
+++ b/app/src/main/java/com/eure/traveling/MyRequest.java
@@ -25,7 +25,7 @@ public class MyRequest {
             final RequestListener.SuccessListener successListener,
             final RequestListener.FailureListener failureListener) {
         return new JsonObjectRequest(
-                "http://api.dribbble.com/shots/" + category + "?page=" + page,
+                "http://api.dribbble.com/shots/" + "?access_token=" + BuildConfig.DRIBBBLE_ACCESS_TOKEN + "&" + category + "?page=" + page,
                 null,
                 new Response.Listener<JSONObject>() {
                     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -15,3 +15,9 @@ allprojects {
         jcenter()
     }
 }
+
+def getDribbbleAccessToken(){
+    def Properties props = new Properties()
+    props.load(new FileInputStream(new File('secrets.properties')))
+    return props['DRIBBBLE_ACCESS_TOKEN']
+}


### PR DESCRIPTION
DribbbleのAPIをつかうのにAccessTokenが必要になっていたので追加
AccessToken自体はバージョン管理に含めないsecrets.propertiesに `DRIBBBLE_ACCESS_TOKEN` で任意に登録できるようにした
